### PR TITLE
Refactored Google Cloud SQL Connection to Use TCP via Serverless VPC

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,23 +10,20 @@ const { body, validationResult } = require('express-validator');
 const app = express();
 app.use(express.json());
 const PORT = process.env.PORT;
-const Knex = require('knex');
 
-const dbConfig = async config => {
-
-  return Knex({
-    client: 'mysql2',
-    connection: {
-      user: process.env.DB_USER, 
-      password: process.env.DB_PASS,
-      database: process.env.DB_NAME,
-      host: process.env.INSTANCE_UNIX_SOCKET,
-    },
-    ...config,
-  });
+const poolConfig = {
+  connectionLimit: 10, // maximum number of connections in the pool
 };
 
-const pool = mysql.createPool({ ...dbConfig });
+const dbConfig = {
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: process.env.DB_NAME,
+};
+
+const pool = mysql.createPool({ ...dbConfig, ...poolConfig });
 
 app.use(express.urlencoded({ extended: true }));
 app.use(session({ secret: process.env.SESSION_SECRET, resave: false, saveUninitialized: false }));


### PR DESCRIPTION
Updated the database connection configuration to utilize TCP connection instead of Unix Sockets for Google Cloud SQL integration. The implementation now leverages Serverless VPC access to establish a secure connection between the application running on Cloud Run and the Cloud SQL instance.

This change ensures compatibility with Cloud Run environments and allows seamless communication between the application and the database. Verified the changes locally and ready for deployment to production.