### PR TITLE
fix: Google Cloud SQL table name inconsistency in database queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ function updateAcademicYear(userEmail, newSemester) {
   const academicYearString = `${academicYear - 1}-${academicYear}`;
 
   // Update the academic year in the Users table
-  const query = `UPDATE Users SET academic_year = ? WHERE email = ?`;
+  const query = `UPDATE users SET academic_year = ? WHERE email = ?`;
   pool.query(query, [academicYearString, userEmail], (error, results) => {
     if (error) {
       console.error('Error updating academic year:', error);


### PR DESCRIPTION
Updated database queries in the codebase to use the correct table name 'users' instead of 'Users' to resolve the error encountered on Cloud SQL console regarding the missing table.