### PR TITLE
fix(login): update placeholder text for login fields

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -33,11 +33,11 @@
                               <form action="/">
                                  <div class="mb-3">
                                     <label class="mb-1"><strong>Email</strong></label>
-                                    <input type="email" class="form-control" value="SVV Net ID">
+                                    <input type="email" class="form-control" placeholder="SVV Net ID">
                                  </div>
                                  <div class="mb-3">
                                     <label class="mb-1"><strong>Password</strong></label>
-                                    <input type="password" class="form-control" value="Password">
+                                    <input type="password" class="form-control" placeholder="Password">
                                  </div>
                                  <div class="row d-flex justify-content-between mt-4 mb-2">
                                     <div class="mb-3">

--- a/public/vendor/global/dashboard.js
+++ b/public/vendor/global/dashboard.js
@@ -39,7 +39,7 @@ document.addEventListener("DOMContentLoaded", function () {
       // Update progress text
       document.getElementById(
         "progressText"
-      ).textContent = `${progress.completed} out of ${progress.total} online courses completed`;
+      ).textContent = `${progress.completed} out of ${progress.total} courses completed`;
 
       // Update the progress chart
       updateProgressChart(progress.percentage);


### PR DESCRIPTION
Updates the placeholder text for the email and password fields on the login page to use the more generic "SVV Net ID" and "Password" instead of pre-populated values.

Updates the progress text to remove the "online" word since the courses being tracked are not necessarily all online. This makes the text more accurate and inclusive of all course types.